### PR TITLE
changed base64 decode param from -D to --decode

### DIFF
--- a/quickstart-with-jenkins/run.sh
+++ b/quickstart-with-jenkins/run.sh
@@ -167,7 +167,7 @@ PROXY_HOST=$(oc get routes/webhook-proxy -ojsonpath='{.spec.host}')
 ##### Pull the secret from secrets yaml, grep the output of the last word, decode it
 #############
 echo_info "Pulling webhook trigger secret..."
-secret=$(oc get secrets -o=jsonpath='{.items[*].data.trigger-secret}' | base64 -D)
+secret=$(oc get secrets -o=jsonpath='{.items[*].data.trigger-secret}' | base64 --decode)
 
 echo_info "Generating Bitbucket token..."
 echo "Please enter your Bitbucket password:"


### PR DESCRIPTION
-D didn't work in my ubuntu vm (running in windows subsystem) and the man gives only -d and --decode as options:

```
Usage: base64 [OPTION]... [FILE]
Base64 encode or decode FILE, or standard input, to standard output.

With no FILE, or when FILE is -, read standard input.

Mandatory arguments to long options are mandatory for short options too.
  -d, --decode          decode data
```

so I changed it to --decode ...
