### PR TITLE
Adds windows support scripts to RDP/SSH to an ODS in a Box

### DIFF
--- a/ODSiaB/win/rdpODSiaB.bat
+++ b/ODSiaB/win/rdpODSiaB.bat
@@ -1,7 +1,7 @@
 @echo off
 ::=========================================================================
 :: Starts an SSM session to a given instance-id and forwards RDP port 3389
-:: to localhost.
+:: to localhost@localPort.
 ::
 :: Usage:
 :: Enter an Instance-ID below and start the script inside a cmd.exe session

--- a/ODSiaB/win/rdpODSiaB.bat
+++ b/ODSiaB/win/rdpODSiaB.bat
@@ -1,0 +1,21 @@
+@echo off
+::=========================================================================
+:: Starts an SSM session to a given instance-id and forwards RDP port 3389
+:: to localhost.
+::
+:: Usage:
+:: Enter an Instance-ID below and start the script inside a cmd.exe session
+::=========================================================================
+ 
+set instanceId="<your_instance_id>"
+set localPort=56789
+
+:: Proxy Setting
+set no_proxy= 127.0.0.1
+set http_proxy=
+set https_proxy=
+ 
+echo --- Press Ctrl-C to stop port forwarding! ---
+
+:: Start SSM Session
+aws ssm start-session --target %instanceId% --document-name AWS-StartPortForwardingSession --parameters portNumber="3389",localPortNumber=%localPort%

--- a/ODSiaB/win/sshODSiaB.bat
+++ b/ODSiaB/win/sshODSiaB.bat
@@ -1,0 +1,23 @@
+@echo off
+::=========================================================================
+:: Starts an SSM session to a given instance-id and forwards SSH port 22
+:: to localhost@localPort.
+::
+:: Usage:
+:: Enter an Instance-ID below and start the script inside a cmd.exe session.
+:: If required modify localPort for localhost and provide proper proxy 
+:: settings.
+::=========================================================================
+ 
+set instanceId="<your_instance_id>"
+set localPort=2222
+
+:: Proxy Setting
+set no_proxy= 127.0.0.1
+set http_proxy=
+set https_proxy=
+ 
+echo --- Press Ctrl-C to stop port forwarding! ---
+
+:: Start SSM Session
+aws ssm start-session --target %instanceId% --document-name AWS-StartPortForwardingSession --parameters portNumber="22",localPortNumber=%localPort%


### PR DESCRIPTION
This PR provides two windows scripts which simply do a port forwarding from an ODS in a Box instance running in AWS to your localhost via AWS SSM client. Those scripts enables RDP or SSH sessions to the ODS in a Box.